### PR TITLE
Fix testing section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ RSpec.shared_context 'axlsx' do
 
     # mimics an ActionView::Template class, presenting a 'source' method
     # to retrieve the content of the template
-    axlsx_binding.eval(ActionView::Template::Handlers::AxlsxBuilder.call(Struct.new(:source).new(File.read(Rails.root.join(*template_path)))))
+    axlsx_binding.eval(ActionView::Template::Handlers::AxlsxBuilder.new.call(Struct.new(:source).new(File.read(Rails.root.join(*template_path)))))
     axlsx_binding.local_variable_get(:wb)
   end
 end


### PR DESCRIPTION
I recently added tests for axlsx partials in one of my projects and had to do the following change in order to make it work since the `call()` method needs an instance. Figured I should update the README as well ;)