### PR TITLE
Fix travis build (and local development testing)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ env:
   - RAILS_VERSION=5.2
   - RAILS_VERSION=6.0
 rvm:
-  - 2.4.7
-  - 2.5.6
-  - 2.6.4
+  - 2.4
+  - 2.5
+  - 2.6
 before_install:
   - gem update bundler
 script:
   spec/ci.rb
 matrix:
   exclude:
-  - rvm: 2.4.7
+  - rvm: 2.4
     env: RAILS_VERSION=6.0

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,6 @@ gem "sqlite3", '~> 1.4', :platform => [:ruby, :mswin, :mingw]
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 gem 'capybara', '~> 2.1'
-gem 'acts_as_xlsx', git: 'https://github.com/caxlsx/acts_as_caxlsx.git'
+gem 'acts_as_caxlsx', git: 'https://github.com/caxlsx/acts_as_caxlsx.git'
 # To use debugger
 # gem 'pry-debugger'

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ when '4.2'
   # gem 'rails', "~> #{ENV['RAILS_VERSION']}.0"
 end
 
+# the dummy apps are set up for sprockets 3
+gem 'sprockets', '~> 3.0'
+
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
 gem "thin"


### PR DESCRIPTION
The travis build was broken because of:

* the changed name of the `acts_as_caxlsx` gem
* sprockets needs to be fixed to 3.x (or need to update dummy apps for sprockets 4)

In addition, I think the specific ruby versions (patch level) were causing travis to be slow (some timeouts) -- using travis's default might make them faster.