### PR TITLE
Improve testing instructions with tracebacks from template errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,9 @@ RSpec.shared_context 'axlsx' do
 
     # mimics an ActionView::Template class, presenting a 'source' method
     # to retrieve the content of the template
-    axlsx_binding.eval(ActionView::Template::Handlers::AxlsxBuilder.new.call(Struct.new(:source).new(File.read(Rails.root.join(*template_path)))))
+    filename = Rails.root.join(*template_path).to_s
+    source = Struct.new(:source).new(File.read(filename))
+    axlsx_binding.eval(ActionView::Template::Handlers::AxlsxBuilder.new.call(source), filename)
     axlsx_binding.local_variable_get(:wb)
   end
 end


### PR DESCRIPTION
This tweaks the testing instructions so that any errors
within the template itself are included in the traceback (this 
makes debugging so much more pleasant).