### PR TITLE
Update Rails version compatibility in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See [previous installations](#previous-installations) if needed.
 
 ## Requirements
 
-* Rails 4.2, 5.0 or 5.1 (tested)
+* Rails 4.2, 5.x (tested), or 6.0 (tested)
 * For Rails 3.1 or 3.2 use version 3.0
 * **As of 0.5.0 requires Axlsx 2.0.1, but strongly suggests 2.1.0.pre, which requires rubyzip 1.1.0**
 * As of Rails 4.1 you must use `render_to_string` to render a mail attachment.


### PR DESCRIPTION
Looks like the gemspec should be updated to require `actionpack >=4.2` as well