### PR TITLE
Test against supported Rails 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ notifications:
       - noel@peden.biz
     on_success: always
 env:
+  - RAILS_VERSION=4.2
   - RAILS_VERSION=5.0
   - RAILS_VERSION=5.1
   - RAILS_VERSION=5.2
@@ -18,7 +19,8 @@ rvm:
   - 2.5
   - 2.6
 before_install:
-  - gem update bundler
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 script:
   spec/ci.rb
 matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -11,18 +11,23 @@ case ENV['RAILS_VERSION']
 when '6.0'
   gem 'rails', "~> 6"
   gem 'responders', '~> 3.0'
+  gem 'sqlite3'
 when '5.2'
   gem 'rails', "~> 5.2"
   gem 'responders', '~> 3.0'
+  gem 'sqlite3'
 when '5.1'
   gem 'rails', "~> 5.1"
   gem 'responders', '~> 3.0'
+  gem 'sqlite3'
 when '5.0'
   gem 'rails', "~> 5.0"
   gem 'responders', '~> 2.0'
+  gem 'sqlite3'
 when '4.2'
   gem 'rails', "~> 4.2"
   gem 'responders', '~> 2.0'
+  gem 'sqlite3', '1.3.13'
 # when '4.1'
   # gem 'rails', "~> 4.1.0"
 # when '4.0'
@@ -37,7 +42,6 @@ gem 'sprockets', '~> 3.0'
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
 gem "thin"
-gem "sqlite3", '~> 1.4', :platform => [:ruby, :mswin, :mingw]
 
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See [previous installations](#previous-installations) if needed.
 
 ## Requirements
 
-* Rails 4.2, 5.x (tested), or 6.0 (tested)
+* Tested on Rails 4.2, 5.x and 6.0
 * For Rails 3.1 or 3.2 use version 3.0
 * **As of 0.5.0 requires Axlsx 2.0.1, but strongly suggests 2.1.0.pre, which requires rubyzip 1.1.0**
 * As of Rails 4.1 you must use `render_to_string` to render a mail attachment.

--- a/axlsx_rails.gemspec
+++ b/axlsx_rails.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara"
   s.add_development_dependency "roo"
   s.add_development_dependency "rubyzip"
-  s.add_development_dependency "sqlite3", '~> 1.4'
   s.add_development_dependency "growl"
   s.add_development_dependency "rb-fsevent"
   s.add_development_dependency "coveralls"

--- a/spec/ci.rb
+++ b/spec/ci.rb
@@ -8,7 +8,7 @@ elsif ENV['RAILS_VERSION'] =~ /^5/
   exit system("cd spec/dummy_#{ENV['RAILS_VERSION']} && bundle install --without debug && rails db:reset && cd ../../ && bundle exec rspec spec")
 elsif ENV['RAILS_VERSION'] =~ /^4/
   puts "Testing Rails #{ENV['RAILS_VERSION'].to_i}"
-  exit system("cd spec/dummy_#{ENV['RAILS_VERSION'].to_i} && bundle install --without debug && bundle exec rake db:create && bundle exec rake db:migrate && cd ../../ && bundle exec rspec spec")
+  exit system("cd spec/dummy_#{ENV['RAILS_VERSION'].to_i} && bundle install --without debug && rake db:reset && cd ../../ && bundle exec rspec spec")
 else
   puts "Testing Rails 3"
   exit system('cd spec/dummy && bundle install --without debug && bundle exec rake db:create && bundle exec rake db:migrate && cd ../../ && bundle exec rspec spec')


### PR DESCRIPTION
Rails 4.2 env entry was removed from Travis CI as a simple workaround for failing tests in 593de1b86b57f9070c5904c5491bcfc32f1df089. As Rails 4.2 is still supported (see the latest merge commit – 237cbbde1a3e763ee208b08424c03d4f00e93cd6) it should be tested against in Travis CI as well.

To understand the changes see https://docs.travis-ci.com/user/languages/ruby/#bundler-20, 9506b5e45acb64ac5d7565d268390622bfbacc65 and Travis CI jobs.